### PR TITLE
Removed deprecated starts_with and used Str::startsWith() in in layout

### DIFF
--- a/resources/views/nova/layout.blade.php
+++ b/resources/views/nova/layout.blade.php
@@ -86,7 +86,7 @@
 
     <!-- Tool Scripts -->
     @foreach (Nova::availableScripts(request()) as $name => $path)
-        @if (starts_with($path, ['http://', 'https://']))
+        @if (Str::startsWith($path, ['http://', 'https://']))
             <script src="{!! $path !!}"></script>
         @else
             <script src="/nova-api/scripts/{{ $name }}"></script>


### PR DESCRIPTION
## Summary of Change
The use of `starts_with` results in undefined function in Laravel 6 because of the deprecated (now removed) `str_*` functions in Laravel 6.

I replaced `starts_with` with `Str::startsWith` to make this work.